### PR TITLE
Iterate over all displays to create screenshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "i3lockr"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "blend-srgb",
  "imagefmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "i3lockr"
 description = "Distort a screenshot and run i3lock"
-version = "1.2.1"
+version = "1.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["Owen Walpole <owenthewizard@hotmail.com>"]
 repository = "https://github.com/owenthewizard/i3lockr"

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         if disp.height() > max_height {
             max_height = disp.height();
         }
-        println!("Found display w/ left {}", disp.left());
     }
 
     let mut multimon_buffer = vec![rgb::alt::BGRA::<u8>::default(); total_width * max_height];


### PR DESCRIPTION
Uses [scrap::Display::all](https://docs.rs/scrap/latest/scrap/struct.Display.html#method.all) to iterate over all available displays and construct a large buffer to hold all the BGRA structured pixels before referencing that in the screenshot `ImgRef`.

This likely needs review to (at least) move the timer commands if I misplaced them when adding code.